### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install platformio
+      - run: pio run -e adafruit_feather_esp32s3_reversetft
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: .pio/build/adafruit_feather_esp32s3_reversetft/firmware.bin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Action for tagged release builds

## Testing
- `pip install platformio` *(fails: Could not find a version that satisfies the requirement platformio)*
- `pio run -e adafruit_feather_esp32s3_reversetft` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c03b4272048327b227a548e6848ba8